### PR TITLE
Config V2 support + a few minor fixes

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1291,9 +1291,9 @@
       }
     },
     "node_modules/vite": {
-      "version": "4.5.0",
-      "resolved": "https://registry.npmjs.org/vite/-/vite-4.5.0.tgz",
-      "integrity": "sha512-ulr8rNLA6rkyFAlVWw2q5YJ91v098AFQ2R0PRFwPzREXOUJQPtFUG0t+/ZikhaOCDqFoDhN6/v8Sq0o4araFAw==",
+      "version": "4.5.1",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-4.5.1.tgz",
+      "integrity": "sha512-AXXFaAJ8yebyqzoNB9fu2pHoo/nWX+xZlaRwoeYUxEqBO+Zj4msE5G+BhGBll9lYEKv9Hfks52PAF2X7qDYXQA==",
       "dev": true,
       "dependencies": {
         "esbuild": "^0.18.10",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,15 +1,15 @@
 {
   "name": "configcat-vue",
-  "version": "2.0.0",
+  "version": "2.0.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "configcat-vue",
-      "version": "2.0.0",
+      "version": "2.0.1",
       "license": "MIT",
       "dependencies": {
-        "configcat-common": "^8.2.0"
+        "configcat-common": "^9.1.0"
       },
       "devDependencies": {
         "@types/node": "^20.8.6",
@@ -800,9 +800,9 @@
       }
     },
     "node_modules/configcat-common": {
-      "version": "8.2.0",
-      "resolved": "https://registry.npmjs.org/configcat-common/-/configcat-common-8.2.0.tgz",
-      "integrity": "sha512-NWCXiiYEPU83wwJkG/vzBGNyvVNRXn0+raIOmE1iG95wKjRkEwB63HdZFD4nCCx449smM9dSNu/Hl+FinNw30A==",
+      "version": "9.1.0",
+      "resolved": "https://registry.npmjs.org/configcat-common/-/configcat-common-9.1.0.tgz",
+      "integrity": "sha512-jaYyCAdSZ8Su0Jr1Dx9eIzXEb66yN0M6Vc7b6ceGAQZ0RzsWDdcAVyRACOLZTH6Zwfz8Sb0o4O9b6QZl2PvUfw==",
       "dependencies": {
         "tslib": "^2.4.1"
       }

--- a/package.json
+++ b/package.json
@@ -57,6 +57,6 @@
     "vue-tsc": "^1.8.5"
   },
   "dependencies": {
-    "configcat-common": "^8.2.0"
+    "configcat-common": "^9.1.0"
   }
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -20,6 +20,7 @@ export function createFlagOverridesFromMap(map: { [name: string]: NonNullable<Se
 }
 
 // These exports should be kept in sync with the exports listed in the section "Public types for end users" of common-js/src/index.ts!
+
 export type {
   IOptions,
   IAutoPollOptions,
@@ -30,18 +31,31 @@ export type {
   LogMessage,
   IConfigCatCache,
   IConfig,
+  ISegment,
+  SettingTypeMap,
+  SettingValue,
+  VariationIdValue,
+  ISettingValueContainer,
+  ISettingUnion,
   ISetting,
   ITargetingRule,
   IPercentageOption,
-  SettingValue,
-  VariationIdValue,
+  ConditionTypeMap,
+  IConditionUnion,
+  ICondition,
+  UserConditionComparisonValueTypeMap,
+  IUserConditionUnion,
+  IUserCondition,
+  IPrerequisiteFlagCondition,
+  ISegmentCondition,
   IConfigCatClient,
   IConfigCatClientSnapshot,
   IEvaluationDetails,
   SettingTypeOf,
+  UserAttributeValue,
   FlagOverrides,
   IProvidesHooks,
-  HookEvents,
+  HookEvents
 } from "configcat-common";
 
 export {
@@ -50,10 +64,12 @@ export {
   LogLevel,
   FormattableLogMessage,
   SettingType,
-  Comparator,
+  UserComparator,
+  PrerequisiteFlagComparator,
+  SegmentComparator,
   SettingKeyValue,
   User,
   OverrideBehaviour,
+  ClientCacheState,
   RefreshResult,
-  ClientReadyState,
 } from "configcat-common";

--- a/src/plugins/ConfigCatPlugin.ts
+++ b/src/plugins/ConfigCatPlugin.ts
@@ -22,16 +22,11 @@ export default {
   // Vue's `App.prototype.use` does not play nicely with generic `install` functions, so we resort to using a discriminated union.
   install: (app: App, options: PluginOptions<PollingMode.AutoPoll> | PluginOptions<PollingMode.LazyLoad> | PluginOptions<PollingMode.ManualPoll>): void => {
     const { sdkKey, pollingMode, clientOptions } = options;
-    const configCatKernel: IConfigCatKernel = {
+    const configCatKernel: IConfigCatKernel = LocalStorageCache.setup({
       sdkType: "ConfigCat-Vue",
       sdkVersion: CONFIGCAT_SDK_VERSION,
       configFetcher: new HttpConfigFetcher(),
-      defaultCacheFactory: (options) =>
-        new configcat.ExternalConfigCache(
-          new LocalStorageCache(),
-          options.logger
-        ),
-    };
+    });
 
     const configCatClient = configcat.getClient(
       sdkKey,

--- a/src/plugins/ConfigFetcher.ts
+++ b/src/plugins/ConfigFetcher.ts
@@ -33,7 +33,7 @@ export class HttpConfigFetcher implements IConfigFetcher {
     }
   }
 
-  fetchLogic(options: OptionsBase, _: string | null): Promise<IFetchResponse> {
+  fetchLogic(options: OptionsBase, lastEtag: string | null): Promise<IFetchResponse> {
     return new Promise<IFetchResponse>((resolve, reject) => {
       try {
         options.logger.debug("HttpConfigFetcher.fetchLogic() called.");
@@ -47,7 +47,12 @@ export class HttpConfigFetcher implements IConfigFetcher {
         httpRequest.onabort = () => reject(new FetchError("abort"));
         httpRequest.onerror = () => reject(new FetchError("failure"));
 
-        httpRequest.open("GET", options.getUrl(), true);
+        let url = options.getUrl();
+        if (lastEtag) {
+          // We are sending the etag as a query parameter so if the browser doesn't automatically adds the If-None-Match header, we can transorm this query param to the header in our CDN provider.
+          url += "&ccetag=" + encodeURIComponent(lastEtag);
+        }
+        httpRequest.open("GET", url, true);
         httpRequest.timeout = options.requestTimeoutMs;
 
         httpRequest.send(null);

--- a/src/plugins/LocalStorageCache.ts
+++ b/src/plugins/LocalStorageCache.ts
@@ -3,7 +3,7 @@ import type { IConfigCatCache } from "configcat-common";
 export class LocalStorageCache implements IConfigCatCache {
   set(key: string, value: string): void {
     try {
-      localStorage.setItem(key, btoa(value));
+      localStorage.setItem(key, toUtf8Base64(value));
     } catch (ex) {
       // local storage is unavailable
     }
@@ -13,11 +13,23 @@ export class LocalStorageCache implements IConfigCatCache {
     try {
       const configString = localStorage.getItem(key);
       if (configString) {
-        return atob(configString);
+        return fromUtf8Base64(configString);
       }
     } catch (ex) {
-      // local storage is unavailable or invalid cache value in local storage
+      // local storage is unavailable or invalid cache value in localstorage
     }
     return void 0;
   }
+}
+
+export function toUtf8Base64(str: string): string {
+  str = encodeURIComponent(str);
+  str = str.replace(/%([0-9A-F]{2})/g, (_, p1) => String.fromCharCode(parseInt(p1, 16)));
+  return btoa(str);
+}
+
+export function fromUtf8Base64(str: string): string {
+  str = atob(str);
+  str = str.replace(/[%\x80-\xFF]/g, m => "%" + m.charCodeAt(0).toString(16));
+  return decodeURIComponent(str);
 }

--- a/src/plugins/LocalStorageCache.ts
+++ b/src/plugins/LocalStorageCache.ts
@@ -1,25 +1,48 @@
-import type { IConfigCatCache } from "configcat-common";
+import type { IConfigCatCache, IConfigCatKernel } from "configcat-common";
+import { ExternalConfigCache } from "configcat-common";
 
 export class LocalStorageCache implements IConfigCatCache {
-  set(key: string, value: string): void {
-    try {
-      localStorage.setItem(key, toUtf8Base64(value));
-    } catch (ex) {
-      // local storage is unavailable
+  static setup(kernel: IConfigCatKernel, localStorageGetter?: () => Storage | null): IConfigCatKernel {
+    const localStorage = (localStorageGetter ?? getLocalStorage)();
+    if (localStorage) {
+      kernel.defaultCacheFactory = options => new ExternalConfigCache(new LocalStorageCache(localStorage), options.logger);
     }
+    return kernel;
+  }
+
+  constructor(private readonly storage: Storage) {
+  }
+
+  set(key: string, value: string): void {
+    this.storage.setItem(key, toUtf8Base64(value));
   }
 
   get(key: string): string | undefined {
-    try {
-      const configString = localStorage.getItem(key);
-      if (configString) {
-        return fromUtf8Base64(configString);
-      }
-    } catch (ex) {
-      // local storage is unavailable or invalid cache value in localstorage
+    const configString = this.storage.getItem(key);
+    if (configString) {
+      return fromUtf8Base64(configString);
     }
-    return void 0;
   }
+}
+
+export function getLocalStorage(): Storage | null {
+  const testKey = "__configcat_localStorage_test";
+
+  try {
+    const storage = window.localStorage;
+    storage.setItem(testKey, testKey);
+
+    let retrievedItem: string | null;
+    try { retrievedItem = storage.getItem(testKey); }
+    finally { storage.removeItem(testKey); }
+
+    if (retrievedItem === testKey) {
+      return storage;
+    }
+  }
+  catch (err) { /* intentional no-op */ }
+
+  return null;
 }
 
 export function toUtf8Base64(str: string): string {


### PR DESCRIPTION
Upgrades the project to configcat-common v9.1.0, which supports the upcoming Config V2 features.

Also, fixes a few minor bugs:
* Send ETag as query param (`ccetag`) in `ConfigFetcher` as a workaround for cases where the browser doesn't append the `If-None-Match` HTTP header automatically.
* Fix bug occurring in `LocalStorageCache` when cache payload contains characters outside the ASCII range.
* Don't swallow exceptions which are thrown in the `LocalStorageCache.get`/`set` methods so the outer exception handlers can catch and log them.