### PR TITLE
Add option for detecting changes to flag overrides

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,15 +1,15 @@
 {
   "name": "configcat-vue",
-  "version": "2.0.1",
+  "version": "2.1.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "configcat-vue",
-      "version": "2.0.1",
+      "version": "2.1.1",
       "license": "MIT",
       "dependencies": {
-        "configcat-common": "^9.1.0"
+        "configcat-common": "^9.2.0"
       },
       "devDependencies": {
         "@types/node": "^20.8.6",
@@ -800,9 +800,9 @@
       }
     },
     "node_modules/configcat-common": {
-      "version": "9.1.0",
-      "resolved": "https://registry.npmjs.org/configcat-common/-/configcat-common-9.1.0.tgz",
-      "integrity": "sha512-jaYyCAdSZ8Su0Jr1Dx9eIzXEb66yN0M6Vc7b6ceGAQZ0RzsWDdcAVyRACOLZTH6Zwfz8Sb0o4O9b6QZl2PvUfw==",
+      "version": "9.2.0",
+      "resolved": "https://registry.npmjs.org/configcat-common/-/configcat-common-9.2.0.tgz",
+      "integrity": "sha512-IPnC+jF947ajb0tKZGhu7nMqJlP+RhQKer7drfygW7G/J2RVV0GVvr2rBGNoAPn38Glf8TOZHsDmXmlCQkMl7g==",
       "dependencies": {
         "tslib": "^2.4.1"
       }

--- a/package.json
+++ b/package.json
@@ -57,6 +57,6 @@
     "vue-tsc": "^1.8.5"
   },
   "dependencies": {
-    "configcat-common": "^9.1.0"
+    "configcat-common": "^9.2.0"
   }
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,11 +1,3 @@
-import {
-  SettingValue,
-  FlagOverrides,
-  MapOverrideDataSource,
-  OverrideBehaviour,
-  createConsoleLogger
-} from "configcat-common";
-
 export {
   default as ConfigCatPlugin,
   type PluginOptions as ConfigCatPluginOptions
@@ -13,11 +5,10 @@ export {
 
 export { default as FeatureWrapper } from './components/FeatureWrapper.vue';
 
-export { createConsoleLogger };
-
-export function createFlagOverridesFromMap(map: { [name: string]: NonNullable<SettingValue>; }, behaviour: OverrideBehaviour) {
-  return new FlagOverrides(new MapOverrideDataSource(map), behaviour);
-}
+export {
+  createConsoleLogger,
+  createFlagOverridesFromMap
+} from "configcat-common";
 
 // These exports should be kept in sync with the exports listed in the section "Public types for end users" of common-js/src/index.ts!
 

--- a/src/plugins/ConfigCatPlugin.ts
+++ b/src/plugins/ConfigCatPlugin.ts
@@ -1,7 +1,6 @@
-import * as configcat from "configcat-common";
 import { HttpConfigFetcher } from "./ConfigFetcher";
 import { LocalStorageCache } from "./LocalStorageCache";
-import { PollingMode } from "configcat-common";
+import { PollingMode, getClient } from "configcat-common";
 import CONFIGCAT_SDK_VERSION from "./Version";
 // Types
 import type { App } from "vue";
@@ -28,7 +27,7 @@ export default {
       configFetcher: new HttpConfigFetcher(),
     });
 
-    const configCatClient = configcat.getClient(
+    const configCatClient = getClient(
       sdkKey,
       pollingMode ?? PollingMode.AutoPoll,
       clientOptions,


### PR DESCRIPTION
Updates the project to include this recent improvement in `configcat-common`: https://github.com/configcat/common-js/pull/101

Adds an optional parameter named `watchChanges` to `createFlagOverridesFromMap` which controls whether the client should detect changes to the flag override map after client initialization.

