### PR TITLE
Upgrade configcat-common to v9.3.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,15 +1,15 @@
 {
   "name": "configcat-vue",
-  "version": "2.2.2",
+  "version": "2.2.5",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "configcat-vue",
-      "version": "2.2.2",
+      "version": "2.2.5",
       "license": "MIT",
       "dependencies": {
-        "configcat-common": "9.2.0"
+        "configcat-common": "9.3.0"
       },
       "devDependencies": {
         "@types/node": "^20.8.6",
@@ -1265,9 +1265,9 @@
       }
     },
     "node_modules/configcat-common": {
-      "version": "9.2.0",
-      "resolved": "https://registry.npmjs.org/configcat-common/-/configcat-common-9.2.0.tgz",
-      "integrity": "sha512-IPnC+jF947ajb0tKZGhu7nMqJlP+RhQKer7drfygW7G/J2RVV0GVvr2rBGNoAPn38Glf8TOZHsDmXmlCQkMl7g==",
+      "version": "9.3.0",
+      "resolved": "https://registry.npmjs.org/configcat-common/-/configcat-common-9.3.0.tgz",
+      "integrity": "sha512-WgpCanLPsT0ig4eLEo2BCZvo0sqtGIkRREnxNAX3Hubw0FzyQ7JUbiliw7ZlBNgda5jaO2nvcs3man+PDdfyLQ==",
       "dependencies": {
         "tslib": "^2.4.1"
       }

--- a/package-lock.json
+++ b/package-lock.json
@@ -2470,9 +2470,9 @@
       }
     },
     "node_modules/vite": {
-      "version": "4.5.1",
-      "resolved": "https://registry.npmjs.org/vite/-/vite-4.5.1.tgz",
-      "integrity": "sha512-AXXFaAJ8yebyqzoNB9fu2pHoo/nWX+xZlaRwoeYUxEqBO+Zj4msE5G+BhGBll9lYEKv9Hfks52PAF2X7qDYXQA==",
+      "version": "4.5.2",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-4.5.2.tgz",
+      "integrity": "sha512-tBCZBNSBbHQkaGyhGCDUGqeo2ph8Fstyp6FMSvTtsXeZSPpSMGlviAOav2hxVTqFcx8Hj/twtWKsMJXNY0xI8w==",
       "dev": true,
       "dependencies": {
         "esbuild": "^0.18.10",

--- a/package.json
+++ b/package.json
@@ -61,6 +61,6 @@
     "vue-tsc": "^1.8.5"
   },
   "dependencies": {
-    "configcat-common": "9.2.0"
+    "configcat-common": "9.3.0"
   }
 }


### PR DESCRIPTION
# Pull Request

**Description:**

A new version of configcat-common has been released, [containing some fixes and improvements](https://github.com/configcat/common-js/releases/tag/v9.3.0). According to the plans, this will be the final version for the upcoming Config V2 feature pack. So, let's upgrade configcat-vue to use this version.

**Changes:**
Upgrade configcat-common to v9.3.0

**Testing:**
Automated tests should be enough.

**Related Issues:**
n/a
